### PR TITLE
Feature #5: Add a `name` configuration option

### DIFF
--- a/src/Configuration.type.ts
+++ b/src/Configuration.type.ts
@@ -1,3 +1,4 @@
 export interface Configuration {
   version: string;
+  name?: string;
 }

--- a/src/Terminal.test.ts
+++ b/src/Terminal.test.ts
@@ -106,6 +106,7 @@ it('info calls console.log with custom prefix', () => {
   terminal.info('hello world');
 
   expect(log_output.mock.calls).toEqual([
+    // NOTE there is an extra space here, so that info/error/warn/debug align
     ['info  -', 'hello world'],
   ]);
 });
@@ -116,7 +117,7 @@ it('debug calls console.log with custom prefix', () => {
   terminal.debug('hello world');
 
   expect(log_output.mock.calls).toEqual([
-    ['\u001b[34mdebug -\u001b[39m', 'hello world'],
+    [style.font_color.blue`debug -`, 'hello world'],
   ]);
 });
 
@@ -126,7 +127,8 @@ it('warn calls console.log with custom prefix', () => {
   terminal.warn('hello world');
 
   expect(log_output.mock.calls).toEqual([
-    ['\u001b[33mwarn  -\u001b[39m', 'hello world'],
+    // NOTE there is an extra space here, so that info/error/warn/debug align
+    [style.font_color.yellow`warn  -`, 'hello world'],
   ]);
 });
 
@@ -136,7 +138,7 @@ it('error calls console.log with custom prefix', () => {
   terminal.error('hello world');
 
   expect(log_output.mock.calls).toEqual([
-    ['\u001b[31merror -\u001b[39m', 'hello world'],
+    [style.font_color.red`error -`, 'hello world'],
   ]);
 });
 

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -165,6 +165,7 @@ export class Terminal {
   }
 
   info(...values: unknown[]): void {
+    // NOTE there is an extra space here, so that info/error/warn/debug align
     console.log('info  -', ...values);
   }
 
@@ -173,6 +174,7 @@ export class Terminal {
   }
 
   warn(...values: unknown[]): void {
+    // NOTE there is an extra space here, so that info/error/warn/debug align
     console.log(style.font_color.yellow`warn  -`, ...values);
   }
 

--- a/src/print_version.test.ts
+++ b/src/print_version.test.ts
@@ -1,4 +1,5 @@
 import { print_version } from './print_version';
+import { bold } from './style';
 
 let std_output: jest.SpiedFunction<typeof process.stdout.write> | null = null;
 beforeEach(() => {
@@ -11,5 +12,5 @@ afterEach(() => {
 
 it('prints the version', () => {
   print_version('example', { version: '42' });
-  expect(std_output?.mock.calls[0][0]).toEqual('\u001b[1mexample\u001b[22m version 42\n');
+  expect(std_output?.mock.calls[0][0]).toEqual(`${bold`example`} version 42\n`);
 });

--- a/src/run_command.test.ts
+++ b/src/run_command.test.ts
@@ -1,16 +1,26 @@
 import { assertDefined } from 'ts-runtime-typecheck';
 import { run_command } from './run_command';
+import { bold } from './style';
 
 const exit = new Error('not a real error');
 
 let process_exit: jest.SpiedFunction<typeof process.exit> | null = null;
+let std_output: jest.SpiedFunction<typeof process.stdout.write> | null = null;
+let process_argv: string[] | null = null;
 
 beforeEach(() => {
   process_exit = jest.spyOn(process, 'exit').mockImplementation(() => { throw exit; });
+  std_output = jest.spyOn(process.stdout, 'write');
+  process_argv = process.argv;
 });
 afterEach(() => {
   process_exit && process_exit.mockRestore();
+  std_output && std_output.mockRestore();
+  assertDefined(process_argv);
+  process.argv = process_argv;
+  process_argv = null;
   process_exit = null;
+  std_output = null;
 });
 
 it('sync action custom exit code', async () => {
@@ -81,4 +91,37 @@ it('failing action default error exit code', async () => {
   expect(process_exit.mock.calls).toEqual([
     [1]
   ]);
+});
+
+it('uses the 2nd process arg for root executable', async () => {
+  assertDefined(std_output);
+  // use the version option to print the executable name
+  process.argv = ['node', 'example', '--version'];
+  try {
+    await run_command({
+      action () {
+        null;
+      }
+    }, { version: '1' });
+  } catch (e) {
+    // test throws harmless error instead of calling process.exit
+  }
+  
+  expect(std_output?.mock.calls[0][0]).toEqual(`${bold`example`} version 1\n`);
+});
+
+it('renames the root executable if specified in configuration', async () => {
+  assertDefined(std_output);
+  // use the version option to print the executable name
+  process.argv = ['node', 'example', '--version'];
+  try {
+    await run_command({
+      action () {
+        null;
+      }
+    }, { version: '1', name: 'special' });
+  } catch (e) {
+    // test throws harmless error instead of calling process.exit
+  }
+  expect(std_output?.mock.calls[0][0]).toEqual(`${bold`special`} version 1\n`);
 });

--- a/src/run_command.ts
+++ b/src/run_command.ts
@@ -2,9 +2,12 @@ import type { Command } from './Command.type';
 import type { Configuration } from './Configuration.type';
 
 import { run_command_with_options } from './run_command_with_options';
-import { parse_argv } from './Argv';
+import { parse_argv, rename_executable } from './Argv';
 
 export async function run_command (command: Command, cfg: Configuration): Promise<void> {
-	const options = parse_argv(process.argv.slice(1));
+	let options = parse_argv(process.argv.slice(1));
+  if (cfg.name) {
+    options = rename_executable(options, cfg.name);
+  }
 	process.exit(await run_command_with_options(command, options, cfg));
 }

--- a/src/run_command_with_options.test.ts
+++ b/src/run_command_with_options.test.ts
@@ -35,14 +35,12 @@ it('execute subcommand', async () => {
 });
 it('execute help subcommand', async () => {
   const result = await run_command_with_options({}, parse_argv(['example', 'help']), cfg);
-  // eslint-disable-next-line no-control-regex
-  expect(std_output?.mock.calls[0][0]).toMatch(/^\u001b\[1mUSAGE:\u001b\[22m example/u);
+  expect(std_output?.mock.calls[0][0]).toEqual(`${style.bold`USAGE:`} example ${style.dim`[options] [command]`}\n`);
   expect(result).toEqual(0);
 });
 it('execute help option', async () => {
   const result = await run_command_with_options({}, parse_argv(['example', '--help']), cfg);
-  // eslint-disable-next-line no-control-regex
-  expect(std_output?.mock.calls[0][0]).toMatch(/^\u001b\[1mUSAGE:\u001b\[22m example/u);
+  expect(std_output?.mock.calls[0][0]).toEqual(`${style.bold`USAGE:`} example ${style.dim`[options] [command]`}\n`);
   expect(result).toEqual(0);
 });
 it('help of subcommand preferred', async () => {
@@ -51,8 +49,7 @@ it('help of subcommand preferred', async () => {
       sub: {}
     }
   }, parse_argv(['example', 'sub', 'help']), cfg);
-  // eslint-disable-next-line no-control-regex
-  expect(std_output?.mock.calls[0][0]).toMatch(/^\u001b\[1mUSAGE:\u001b\[22m example sub/u);
+  expect(std_output?.mock.calls[0][0]).toEqual(`${style.bold`USAGE:`} example sub ${style.dim`[options] [command]`}\n`);
   expect(result).toEqual(0);
 });
 it('execute version subcommand', async () => {
@@ -141,7 +138,6 @@ it('handles a misspelt subcommand', async () => {
 });
 it('default help execution', async () => {
   const result = await run_command_with_options({}, parse_argv(['example']), cfg);
-  // eslint-disable-next-line no-control-regex
-  expect(std_output?.mock.calls[0][0]).toMatch(/^\u001b\[1mUSAGE:\u001b\[22m example/u);
+  expect(std_output?.mock.calls[0][0]).toEqual(`${style.bold`USAGE:`} example ${style.dim`[options] [command]`}\n`);
   expect(result).toEqual(0);
 });


### PR DESCRIPTION
Closes #5

Introduces a new optional value `name` to configuration which overrides the standard executable name taken from the `process.argv`.