### PR TITLE
MC-8870 add support for select/multiselect/autocomplete in terminal

### DIFF
--- a/src/Terminal.test.ts
+++ b/src/Terminal.test.ts
@@ -240,11 +240,11 @@ it('input calls enquirer', async () => {
 it('options calls enquirer', async () => {
   assertDefined(enquirer_prompt);
   enquirer_prompt.mockResolvedValue({ result: 'yes' });
-  expect(await terminal.options('example', ['yes', 'no'])).toEqual('yes');
+  expect(await terminal.select('example', ['yes', 'no'])).toEqual('yes');
 });
 
 it('cancelled options prompt call process.exit', async () => {
-  await expect(() => terminal.options('example', ['yes'])).rejects.toEqual(exit);
+  await expect(() => terminal.select('example', ['yes'])).rejects.toEqual(exit);
   expect(process_exit?.mock.calls).toEqual([
     [1]
   ]);

--- a/src/Terminal.test.ts
+++ b/src/Terminal.test.ts
@@ -237,6 +237,19 @@ it('input calls enquirer', async () => {
   expect(await terminal.input('example', 'yes')).toEqual('yes');
 });
 
+it('options calls enquirer', async () => {
+  assertDefined(enquirer_prompt);
+  enquirer_prompt.mockResolvedValue({ result: 'yes' });
+  expect(await terminal.options('example', ['yes', 'no'])).toEqual('yes');
+});
+
+it('cancelled options prompt call process.exit', async () => {
+  await expect(() => terminal.options('example', ['yes'])).rejects.toEqual(exit);
+  expect(process_exit?.mock.calls).toEqual([
+    [1]
+  ]);
+});
+
 it('cancelled confirm prompt call process.exit', async () => {
   await expect(() => terminal.confirm('example')).rejects.toEqual(exit);
   expect(process_exit?.mock.calls).toEqual([

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -19,6 +19,20 @@ export class Terminal {
     return this.prompt(message, 'input', initial);
   }
 
+  async options<T extends string = string>(message: string, choices: T[], type: 'select' | 'autocomplete' | 'multiselect' = 'select'): Promise<T> {
+    try {
+      const { result } = await prompt<{ result: T }>({
+        type,
+        name: 'result',
+        message,
+        choices, 
+      });
+      return result;
+    } catch {
+      process.exit(EXIT_CODE.error);
+    }
+  }
+
   private async prompt<T>(message: string, type: string, initial: T): Promise<T> {
     try {
       const { result } = await prompt<{ result: T }>({

--- a/src/Terminal.ts
+++ b/src/Terminal.ts
@@ -19,7 +19,7 @@ export class Terminal {
     return this.prompt(message, 'input', initial);
   }
 
-  async options<T extends string = string>(message: string, choices: T[], type: 'select' | 'autocomplete' | 'multiselect' = 'select'): Promise<T> {
+  async select<T extends string = string>(message: string, choices: T[], type: 'select' | 'autocomplete' | 'multiselect' = 'select'): Promise<T> {
     try {
       const { result } = await prompt<{ result: T }>({
         type,


### PR DESCRIPTION
Adds a new method to terminal `select` which allows multiple choice style interactivity. Alt modes for auto complete and multi select.