### PR TITLE
prevent accidental early exit

### DIFF
--- a/src/run_command.test.ts
+++ b/src/run_command.test.ts
@@ -71,9 +71,7 @@ it('sync action default exit code', async () => {
   } catch {
     // test throws harmless error instead of calling process.exit
   }
-  expect(process_exit.mock.calls).toEqual([
-    [0],
-  ]);
+  expect(process_exit.mock.calls.length).toEqual(0);
 });
 
 it('failing action default error exit code', async () => {

--- a/src/run_command.ts
+++ b/src/run_command.ts
@@ -3,11 +3,15 @@ import type { Configuration } from './Configuration.type';
 
 import { run_command_with_options } from './run_command_with_options';
 import { parse_argv, rename_executable } from './Argv';
+import { isNumber } from 'ts-runtime-typecheck';
 
 export async function run_command (command: Command, cfg: Configuration): Promise<void> {
   let options = parse_argv(process.argv.slice(1));
   if (cfg.name) {
     options = rename_executable(options, cfg.name);
   }
-  process.exit(await run_command_with_options(command, options, cfg));
+  const code = await run_command_with_options(command, options, cfg);
+  if (isNumber(code)) {
+    process.exit(code);
+  }
 }

--- a/src/run_command_with_options.test.ts
+++ b/src/run_command_with_options.test.ts
@@ -31,7 +31,7 @@ it('execute subcommand', async () => {
     }
   }, parse_argv(['example', 'test', 'data']), cfg);
   expect(did_run).toEqual(true);
-  expect(result).toEqual(0);
+  expect(result).toEqual(undefined);
 });
 it('execute help subcommand', async () => {
   const result = await run_command_with_options({}, parse_argv(['example', 'help']), cfg);
@@ -76,7 +76,7 @@ it('execute default subcommand', async () => {
     default: 'list',
   }, parse_argv(['example', 'arg']), cfg);
   expect(did_run).toEqual(true);
-  expect(result).toEqual(0);
+  expect(result).toEqual(undefined);
 });
 it('execute default subcommand', async () => {
   await expect(() => run_command_with_options({
@@ -89,7 +89,7 @@ it('returns default exit code for successful action', async () => {
       // no-op
     }
   }, parse_argv(['example', 'arg']), cfg);
-  expect(result).toEqual(0);
+  expect(result).toEqual(undefined);
 });
 it('returns custom exit code for successful action', async () => {
   const result = await run_command_with_options({

--- a/src/run_command_with_options.ts
+++ b/src/run_command_with_options.ts
@@ -11,7 +11,7 @@ import { read_boolean_option, remove_executable, rename_executable, rename_execu
 import { EXIT_CODE } from './exit_code.constants';
 import { terminal } from './Terminal';
 
-export async function run_command_with_options (command: Command, opts: Argv, cfg: Configuration): Promise<number> {
+export async function run_command_with_options (command: Command, opts: Argv, cfg: Configuration): Promise<number | void> {
   const executable = basename(opts.arguments[0]);
   const subcommand_name = opts.arguments[1];
   const subcommand = command.subcommands?.[subcommand_name];
@@ -46,8 +46,7 @@ export async function run_command_with_options (command: Command, opts: Argv, cf
   if (command.action) {
     const child_options = remove_executable(opts);
     try {
-      const code = await command.action(child_options);
-      return code ?? EXIT_CODE.ok;
+      return await command.action(child_options);
     } catch (err) {
       if (err instanceof Error) {
         terminal.error(err.message);


### PR DESCRIPTION
In the situation that the command action doesn't return a promise indicating the completion status programs were exiting early. It's not always easy to cleanly implement such a flow, and Node.js will exit automatically if the event loop is empty. So this allows for optional process exit calls.