### PR TITLE
add reusable multline

### DIFF
--- a/src/run_command_with_options.test.ts
+++ b/src/run_command_with_options.test.ts
@@ -5,17 +5,13 @@ import * as style from './style';
 const cfg = { version: '1' };
 
 let std_output: jest.SpiedFunction<typeof process.stdout.write> | null = null;
-let log_output: jest.SpiedFunction<typeof console.log> | null = null;
 
 beforeEach(() => {
   std_output = jest.spyOn(process.stdout, 'write');
-  log_output = jest.spyOn(console, 'log');
 });
 afterEach(() => {
   std_output && std_output.mockRestore();
-  log_output && log_output.mockRestore();
   std_output = null;
-  log_output = null;
 });
 
 it('execute subcommand', async () => {
@@ -106,8 +102,9 @@ it('handles a thrown error in an action', async () => {
     }
   }, parse_argv(['example']), cfg);
   expect(result).toEqual(1);
-  expect(log_output?.mock.calls).toEqual([
-    [style.font_color.red`error -`, 'BANG'],
+  expect(std_output?.mock.calls).toEqual([
+    [`${style.font_color.red`error`} - BANG\n`],
+    ['\n']
   ]);
 });
 it('handles a thrown value in an action', async () => {
@@ -117,8 +114,9 @@ it('handles a thrown value in an action', async () => {
     }
   }, parse_argv(['example']), cfg);
   expect(result).toEqual(1);
-  expect(log_output?.mock.calls).toEqual([
-    [style.font_color.red`error -`, 'BANG'],
+  expect(std_output?.mock.calls).toEqual([
+    [`${style.font_color.red`error`} - 'BANG'\n`],
+    ['\n']
   ]);
 });
 it('handles a misspelt subcommand', async () => {

--- a/src/run_command_with_options.ts
+++ b/src/run_command_with_options.ts
@@ -10,6 +10,8 @@ import { print_version } from './print_version';
 import { read_boolean_option, remove_executable, rename_executable, rename_executable_and_remove_subcommmand, root_executable } from './Argv';
 import { EXIT_CODE } from './exit_code.constants';
 import { terminal } from './Terminal';
+import { font_color } from './style';
+import util from 'util';
 
 export async function run_command_with_options (command: Command, opts: Argv, cfg: Configuration): Promise<number | void> {
   const executable = basename(opts.arguments[0]);
@@ -49,12 +51,11 @@ export async function run_command_with_options (command: Command, opts: Argv, cf
       return await command.action(child_options);
     } catch (err) {
       if (err instanceof Error) {
-        terminal.error(err.message);
-        terminal.new_line();
+        terminal.print_line(`${font_color.red`error`} - ${err.message}`);
       } else {
-        terminal.error(err);
-        terminal.new_line();
+        terminal.print_line(`${font_color.red`error`} - ${util.inspect(err)}`);
       }
+      terminal.new_line();
       return EXIT_CODE.error;
     }
   }


### PR DESCRIPTION
- rename terminal.reusable_line to reusable_block
- change newline behaviour for dirty flag to prevent append
- remove info, debug, warn and error from terminal
- upgrade reusable_block to allow a variable number of lines