### PR TITLE
add `parameters` option to command

### DIFF
--- a/src/Command.type.ts
+++ b/src/Command.type.ts
@@ -7,5 +7,6 @@ export interface Command {
   options?: Dictionary<string>;
   default?: string;
   examples?: string[];
+  parameters?: number;
   action?: (opts: Argv) => Promise<void | number> | number | void;
 }

--- a/src/print_help.test.ts
+++ b/src/print_help.test.ts
@@ -15,7 +15,52 @@ it('prints usage + inbuilt options/commands with stub', () => {
   assertDefined(std_output);
   print_help('example', {});
   expect(std_output.mock.calls.map(([str]) => str)).toEqual([
+    `${style.bold`USAGE:`} example ${style.dim`[options]`}\n`,
+    '\n',
+    style.bold('COMMANDS:') + '\n',
+    `  help      ${style.dim('Display help')}\n  version   ${style.dim('Display version')}\n`,
+    '\n',
+    style.bold('OPTIONS:') + '\n',
+    `  --help    ${style.dim('Output usage information')}\n  --version ${style.dim('Output the version number')}\n`,
+    '\n',
+  ]);
+});
+
+it('prints "command" in usage if subcommands are present', () => {
+  assertDefined(std_output);
+  print_help('example', { subcommands: {} });
+  expect(std_output.mock.calls.map(([str]) => str)).toEqual([
     `${style.bold`USAGE:`} example ${style.dim`[options] [command]`}\n`,
+    '\n',
+    style.bold('COMMANDS:') + '\n',
+    `  help      ${style.dim('Display help')}\n  version   ${style.dim('Display version')}\n`,
+    '\n',
+    style.bold('OPTIONS:') + '\n',
+    `  --help    ${style.dim('Output usage information')}\n  --version ${style.dim('Output the version number')}\n`,
+    '\n',
+  ]);
+});
+
+it('prints "[...arguments]" in usage if Infinite params are specified', () => {
+  assertDefined(std_output);
+  print_help('example', { parameters: Infinity });
+  expect(std_output.mock.calls.map(([str]) => str)).toEqual([
+    `${style.bold`USAGE:`} example ${style.dim`[options] [...arguments]`}\n`,
+    '\n',
+    style.bold('COMMANDS:') + '\n',
+    `  help      ${style.dim('Display help')}\n  version   ${style.dim('Display version')}\n`,
+    '\n',
+    style.bold('OPTIONS:') + '\n',
+    `  --help    ${style.dim('Output usage information')}\n  --version ${style.dim('Output the version number')}\n`,
+    '\n',
+  ]);
+});
+
+it('prints individual args in usage if parameters are specified', () => {
+  assertDefined(std_output);
+  print_help('example', { parameters: 3 });
+  expect(std_output.mock.calls.map(([str]) => str)).toEqual([
+    `${style.bold`USAGE:`} example ${style.dim`[options]${' [arg1] [arg2] [arg3]'}`}\n`,
     '\n',
     style.bold('COMMANDS:') + '\n',
     `  help      ${style.dim('Display help')}\n  version   ${style.dim('Display version')}\n`,
@@ -64,7 +109,7 @@ it('prints description', () => {
   expect(std_output.mock.calls.map(([str]) => str)).toEqual([
     'something about example\n',
     '\n',
-    `${style.bold`USAGE:`} example ${style.dim`[options] [command]`}\n`,
+    `${style.bold`USAGE:`} example ${style.dim`[options]`}\n`,
     '\n',
     style.bold('COMMANDS:') + '\n',
     `  help      ${style.dim('Display help')}\n  version   ${style.dim('Display version')}\n`,
@@ -85,7 +130,7 @@ it('prints examples', () => {
   });
 
   expect(std_output.mock.calls.map(([str]) => str)).toEqual([
-    `${style.bold`USAGE:`} example ${style.dim`[options] [command]`}\n`,
+    `${style.bold`USAGE:`} example ${style.dim`[options]`}\n`,
     '\n',
     style.bold('EXAMPLES:') + '\n',
     `  ${style.dim`${'example'} ${'two'}`}\n`,

--- a/src/print_help.ts
+++ b/src/print_help.ts
@@ -48,7 +48,22 @@ export function print_help(executable: string, command: Command): void {
     terminal.new_line();
   };
 
-  terminal.print_line(`${style.bold`USAGE:`} ${exe_name} ${style.dim`[options] [command]`}`);
+  if (command.subcommands) {
+    terminal.print_line(`${style.bold`USAGE:`} ${exe_name} ${style.dim`[options] [command]`}`);
+  } else {
+    const max_parameters = command.parameters ?? 0;
+    if (max_parameters === Infinity) {
+      terminal.print_line(`${style.bold`USAGE:`} ${exe_name} ${style.dim`[options] [...arguments]`}`);
+    } else if (max_parameters > 0) {
+      const parameters = [];
+      for (let i = 0; i < max_parameters; i += 1) {
+        parameters.push(` [arg${i + 1}]`);
+      }
+      terminal.print_line(`${style.bold`USAGE:`} ${exe_name} ${style.dim`[options]${parameters.join('')}`}`);
+    } else {
+      terminal.print_line(`${style.bold`USAGE:`} ${exe_name} ${style.dim`[options]`}`);
+    }
+  }
   terminal.new_line();
 
   // NOTE this used to be optional based on if examples existed

--- a/src/run_command_with_options.test.ts
+++ b/src/run_command_with_options.test.ts
@@ -193,3 +193,49 @@ it('suggests a subcommand if subcommands are defined and there are too many argu
     '\n',
   ]);
 });
+it('suggests a subcommand if subcommands are defined and there are too many arguments for the default subcommand', async () => {
+  let did_run = false;
+  const result = await run_command_with_options({
+    subcommands: {
+      alpha: {},
+    },
+    default: 'alpha',
+    action () {
+      did_run = true;
+      // no-op
+    },
+  }, parse_argv(['example', 'alfa', 'beta']), cfg);
+
+  expect(did_run).toBeFalsy();
+  expect(result).toEqual(EXIT_CODE.error);
+  expect(std_output?.mock.calls.map(str => str[0].toString())).toEqual([
+    '\'alfa\' is not a example command. See \'example help\' for a list of available commands.\n',
+    '\n',
+    'Did you mean\n',
+    '  example alpha\n',
+    '\n',
+  ]);
+});
+it('accepts arguments for a default subcommand', async () => {
+  let did_run = false;
+  
+  const result = await run_command_with_options({
+    subcommands: {
+      alpha: {
+        parameters: 1,
+        action (opts) {
+          expect(opts.arguments).toStrictEqual([ 'beta' ]);
+          return 42;
+        }
+      },
+    },
+    default: 'alpha',
+    action () {
+      did_run = true;
+      // no-op
+    },
+  }, parse_argv(['example', 'alpha', 'beta']), cfg);
+
+  expect(did_run).toBeFalsy();
+  expect(result).toBe(42);
+});

--- a/src/run_command_with_options.ts
+++ b/src/run_command_with_options.ts
@@ -7,10 +7,10 @@ import { basename } from 'path';
 import { print_did_you_mean } from './print_did_you_mean';
 import { print_help } from './print_help';
 import { print_version } from './print_version';
-import { read_boolean_option, remove_executable, rename_executable, rename_executable_and_remove_subcommmand, root_executable } from './Argv';
+import { nice_executable_name, read_boolean_option, remove_executable, rename_executable, rename_executable_and_remove_subcommmand, root_executable } from './Argv';
 import { EXIT_CODE } from './exit_code.constants';
 import { terminal } from './Terminal';
-import { font_color } from './style';
+import { bold, font_color } from './style';
 import util from 'util';
 
 export async function run_command_with_options (command: Command, opts: Argv, cfg: Configuration): Promise<number | void> {
@@ -47,6 +47,21 @@ export async function run_command_with_options (command: Command, opts: Argv, cf
   // NOTE if the command has an action attached to it then we should execute that
   if (command.action) {
     const child_options = remove_executable(opts);
+    const max_parameters = command.parameters ?? 0;
+    const argument_count = child_options.arguments.length;
+
+    if (argument_count > max_parameters) {
+      if (subcommand_name && command.subcommands) {
+        print_did_you_mean(command, executable, subcommand_name);
+      } else {
+        terminal
+          .print_line(`${font_color.red`error`} - ${bold(nice_executable_name(executable))} expects up to ${max_parameters} arguments but received ${argument_count}.`)
+          .new_line();
+      }
+      
+      return EXIT_CODE.error;
+    }
+
     try {
       return await command.action(child_options);
     } catch (err) {

--- a/src/run_command_with_options.ts
+++ b/src/run_command_with_options.ts
@@ -40,6 +40,15 @@ export async function run_command_with_options (command: Command, opts: Argv, cf
     if (!subcommand) {
       throw new Error(`Implementation fault: default command ${command.default} does not exist as a subcommand of ${executable}.`);
     }
+    
+    const max_parameters = subcommand.parameters ?? 0;
+    const argument_count = opts.arguments.length - 1;
+
+    if (argument_count > max_parameters && command.subcommands) {
+      print_did_you_mean(command, executable, subcommand_name);
+      return EXIT_CODE.error;
+    }
+
     const child_options = rename_executable(opts, `${executable}-${command.default}`);
     return run_command_with_options(subcommand, child_options, cfg);
   }
@@ -51,7 +60,7 @@ export async function run_command_with_options (command: Command, opts: Argv, cf
     const argument_count = child_options.arguments.length;
 
     if (argument_count > max_parameters) {
-      if (subcommand_name && command.subcommands) {
+      if (command.subcommands) {
         print_did_you_mean(command, executable, subcommand_name);
       } else {
         terminal


### PR DESCRIPTION
- validate the number of passed arguments matches parameter count
- default value of 0 parameters
- improve `usage` help text based on subcommand/parameters fields